### PR TITLE
Moved bs-platform to devDependencies, added npm link to README steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Early, experimental version of BuckleScript / ReasonReact / bs-react-native supp
 yarn global add create-react-native-app
 create-react-native-app HelloWorldRe --scripts-version reason-react-native-scripts
 cd HelloWorldRe
+npm link bs-platform  # yarn link has an issue as of Nov '17: https://github.com/yarnpkg/yarn/issues/4655
 yarn start
 ```
 

--- a/src/scripts/init.js
+++ b/src/scripts/init.js
@@ -13,13 +13,13 @@ const DEFAULT_DEPENDENCIES = {
   expo: '^24.0.0',
   react: '16.0.0',
   'react-native': '0.51.0',
-  'bs-platform': '^2.1.0',
   'bs-react-native': '~0.5.0',
   'reason-react': '~0.3.0',
 };
 
 // TODO figure out how this interacts with ejection
 const DEFAULT_DEV_DEPENDENCIES = {
+  'bs-platform': '^2.1.0',
 };
 
 module.exports = async (


### PR DESCRIPTION
This way bs-platform can be global and shared, rather than replicated in each project.